### PR TITLE
Fixed RDS window from appearing on all pages

### DIFF
--- a/plugins/PiDecode/PiDecodePlugin.js
+++ b/plugins/PiDecode/PiDecodePlugin.js
@@ -65,7 +65,9 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    createPiDecodeContainer(); // Setup the PI decode panel
+    if (window.location.pathname === '/') {
+	    createPiDecodeContainer(); // Setup the PI decode panel
+	}
 
     loadDatabase(function(database) {
         updatePiDecode(database); // Populate the PI decode info initially


### PR DESCRIPTION
I have updated the code to only create the RDS window on the main listening page.  It was appearing on the setup page and creating a gap at the bottom.